### PR TITLE
chore: use the org param

### DIFF
--- a/nvidia-gpu/main.go
+++ b/nvidia-gpu/main.go
@@ -28,7 +28,7 @@ type Gpu struct{}
 func (m *Gpu) DeployDaggerOnFly(ctx context.Context, token *dagger.Secret, org string) (string, error) {
 	dagr := dag.Dagrr(dagger.DagrrOpts{})
 	dagrOnFly := dagr.OnFlyio(token, dagger.DagrrOnFlyioOpts{
-		Org: "dagger",
+		Org: org,
 	})
 
 	manifestDir := dagrOnFly.Manifest(dagger.DagrrFlyManifestOpts{


### PR DESCRIPTION
Currently, the modules has the `dagger` org hardcoded ; update the module to rely on the param